### PR TITLE
[fix] 상용 카프카가 아닌 로컬 카프카 기본 연결 오류 수정

### DIFF
--- a/.github/workflows/prod_cd.yml
+++ b/.github/workflows/prod_cd.yml
@@ -22,7 +22,6 @@ jobs:
           password: ${{ secrets.STAGE_SSH_PASSWORD }}
           script: |
             set -e
-
              mkdir -p /home/ubuntu/gogo-profanity-filter-prod
              cd /home/ubuntu/gogo-profanity-filter-prod
 
@@ -39,7 +38,7 @@ jobs:
              docker stop gogo-profanity-filter-prod || true
              docker rm gogo-profanity-filter-prod || true
 
-             docker run -d --add-host host.docker.internal:host-gateway --env-file .env --name gogo-profanity-filter-prod gogo-profanity-filter-prod
+             docker run -d --env-file .env --name gogo-profanity-filter-prod gogo-profanity-filter-prod
 
       - name: SSH Success Notification
         if: success()


### PR DESCRIPTION
## 개요
로컬 카프카 기본 연결 비활성화
## 변경 사항 
prod 스크립트에서 docker run 시 기본 로컬 호스트 연결 세팅 부분을 삭제