### PR TITLE
[fix] Test 데이터셋 추가 및 사람, 골대 추가 전처리

### DIFF
--- a/AI_relay/datapreprocessing/Make_yoloYaml.py
+++ b/AI_relay/datapreprocessing/Make_yoloYaml.py
@@ -3,8 +3,10 @@ import yaml
 
 data = {
     "train" : 'C:\\Users\\kdyeo\\gogo\\Training\\',
-        "val" : 'C:\\Users\\kdyeo\\gogo\\Validation\\',
-        "names" : {0: 'ball'}}
+    "val" : 'C:\\Users\\kdyeo\\gogo\\Validation\\',
+    "test" : 'C:\\Users\\kdyeo\\gogo\\Test\\',
+    "nc" : 3,
+        "names" : {0: 'ball', 1: 'player', 2: 'goal'},}
 
 with open('G:\\다른 컴퓨터\\내 노트북\\ai\\gogo v3\\AI_relay\\yolo.yaml', 'w') as f :
     yaml.dump(data, f)

--- a/AI_relay/datapreprocessing/drawBoundingBox.py
+++ b/AI_relay/datapreprocessing/drawBoundingBox.py
@@ -12,6 +12,8 @@ image_filename = "E01_EE01_221110_T007_CH08_Z01_f000362.jpg"  # 이미지 파일
 
 class_colors = {
     0: (0, 0, 255),  # 공 - 빨간색
+    1: (0, 255, 0),  # 선수 - 초록색
+    2: (255, 0, 0),  # 골대 - 파란색
 }
 
 image_path = os.path.join(image_folder_path, image_filename)

--- a/AI_relay/datapreprocessing/make_test_dataset.py
+++ b/AI_relay/datapreprocessing/make_test_dataset.py
@@ -1,0 +1,27 @@
+import os
+import shutil
+import random
+
+valid_img_dir = f"C:\\Users\\kdyeo\\gogo\\Validation\\images\\"
+valid_label_dir = f"C:\\Users\\kdyeo\\gogo\\Validation\\json_labels\\"
+test_img_dir = f"C:\\Users\\kdyeo\\gogo\\Test\\images\\"
+test_label_dir = f"C:\\Users\\kdyeo\\gogo\\Test\\json_labels\\"
+
+os.makedirs(test_img_dir, exist_ok=True)
+os.makedirs(test_label_dir, exist_ok=True)
+
+image_files = sorted(os.listdir(valid_img_dir))
+json_files = sorted(os.listdir(valid_label_dir))
+
+assert all(os.path.splitext(f)[0] == os.path.splitext(j)[0] for f, j in zip(image_files, json_files))
+
+num_to_move = len(image_files) // 2  # 2250
+selected = random.sample(image_files, num_to_move)  
+
+for img_file in selected:
+    base_name = os.path.splitext(img_file)[0]
+    json_file = base_name + '.json'
+
+    # 이동
+    shutil.move(os.path.join(valid_img_dir, img_file), os.path.join(test_img_dir, img_file))
+    shutil.move(os.path.join(valid_label_dir, json_file), os.path.join(test_label_dir, json_file))

--- a/AI_relay/datapreprocessing/yoloFormat.py
+++ b/AI_relay/datapreprocessing/yoloFormat.py
@@ -5,13 +5,13 @@ import os
 import tqdm
 
 
-datatype=["Training","Validation"]
+datatype=["Training","Validation","Test"]
 for data_type in datatype:
     label_folder_path = f"C:\\Users\\kdyeo\\gogo\\{data_type}\\json_labels\\"
     image_folder_pah = f"C:\\Users\\kdyeo\\gogo\\{data_type}\\images\\"
     output_folder_path = f"C:\\Users\\kdyeo\\gogo\\{data_type}\\labels"
     file_list = os.listdir(label_folder_path)
-    class_dict = {"공": 0}
+    class_dict = {"선수": 0, "공": 1, "골대": 2}
     os.makedirs(output_folder_path, exist_ok=True)
 
     for file in tqdm.tqdm(file_list, desc=f"Converting {data_type} labels"):
@@ -29,7 +29,7 @@ for data_type in datatype:
         
         with open(yolo_label_path, "w") as yolo_file:
             for obj in data["annotation"]:
-                if "box" in obj:
+                if "box" in obj:  # 선수, 공
                     label = obj["box"]["label"]
                     if label in class_dict:
                         points = obj["box"]["location"][0]
@@ -41,5 +41,22 @@ for data_type in datatype:
 
                         # YOLO 포맷 저장
                         yolo_file.write(f"{class_dict[label]} {x_center} {y_center} {width} {height}\n")
+
+                elif "polygon" in obj and obj["polygon"]["label"] == "골대":  # 골대 (Polygon → BBox 변환)
+                    points = obj["polygon"]["location"][0]
+                    x_values = [points[f"x{i}"] for i in range(1, len(points) // 2 + 1)]
+                    y_values = [points[f"y{i}"] for i in range(1, len(points) // 2 + 1)]
+
+                    x_min, x_max = min(x_values), max(x_values)
+                    y_min, y_max = min(y_values), max(y_values)
+                    width = x_max - x_min
+                    height = y_max - y_min
+                    x_center = (x_min + width / 2) / img_width
+                    y_center = (y_min + height / 2) / img_height
+                    width /= img_width
+                    height /= img_height
+
+                    # YOLO 포맷 저장
+                    yolo_file.write(f"{class_dict['골대']} {x_center} {y_center} {width} {height}\n")
 
 print("YOLO 라벨 변환 완료!")

--- a/AI_relay/yolo.yaml
+++ b/AI_relay/yolo.yaml
@@ -1,4 +1,8 @@
 names:
   0: ball
+  1: player
+  2: goal
+nc: 3
+test: C:\Users\kdyeo\gogo\Test\
 train: C:\Users\kdyeo\gogo\Training\
 val: C:\Users\kdyeo\gogo\Validation\


### PR DESCRIPTION
## 개요 
기존 학습 모델의 성능이 좋지 않아 이를 해결하기 위함
## 변경 사항
- 기존 Train, valid 뿐만으로 이루어진 데이터 셋으로 인한 과적합이 예상되어 제대로 된 성능 측정을 위해 validation dataset의 절반인 2250개의 데이터셋으로 test dataset을 구성하였음
- 공만 추출하였던 기존 커스텀 yolo 데이터셋에 사람, 골대를 추가로 전처리하여 추가하도록 함, test dataset의 경로도 추가하였음