### PR TITLE
[feat] 학습 및 하이퍼파라미터 튜닝 시 중단 세션 저장

### DIFF
--- a/AI_relay/hype_tuning.py
+++ b/AI_relay/hype_tuning.py
@@ -7,10 +7,12 @@ model = YOLO('yolo11m.pt')
 model.tune(
     data='./yolo.yaml',
     epochs=5,              
-    iterations=25,   #하이퍼파라미터튜닝 횟수
+    iterations=50,   #하이퍼파라미터튜닝 횟수
     imgsz=1280,             
     device='cuda',
     batch=4,      
     optimizer='Adam',        
-    plots=True              
+    plots=True,
+    name='tune_exp',
+    resume=True,  #이전 튜닝 결과를 이어서 진행                 
 )

--- a/AI_relay/train.py
+++ b/AI_relay/train.py
@@ -9,9 +9,10 @@ def main():
         epochs=50,
         imgsz=1280,
         batch=4,
-        name='exp1',  
+        name='train_exp',  
         device='cuda',  
         verbose=True,
+        resume=True,  #이전 훈련 결과를 이어서 진행
     )
 
   


### PR DESCRIPTION
## 개요
학교 pc가 저녁마다 전원이 끊겨 강제적으로 진행중인 세션이 모두 날라가는 문제 해결
## 변경사항
train.py와 hype_tuning 에 resume 매개변수를 추가해주어 중간에 세션이 멈추었을때 코드 재실행 시 중단된 세션을 재개할 수 있게 해주었습니다. 
또한 각각 파라미터가 저장되는 폴더를 train_exp와 tune_exp로 나누어 주었습니다.