### PR TITLE
[fix] 추론 모델 싱글톤 캐싱 적용

### DIFF
--- a/gogo_ai_backend/predict_model.py
+++ b/gogo_ai_backend/predict_model.py
@@ -1,43 +1,70 @@
-from transformers import AutoModelForSequenceClassification, AutoTokenizer
-import torch
-import pandas as pd
 import asyncio
+import logging
+from typing import Optional
 
-async def initialize_model_and_tokenizer(hf_model, device):
-    model = AutoModelForSequenceClassification.from_pretrained(
-        hf_model, trust_remote_code=True, use_auth_token=False
-    )
-    tokenizer = AutoTokenizer.from_pretrained("beomi/KcELECTRA-base")
-    model.to(device)
-    model.eval()
-    return model, tokenizer
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
-async def predict_sentence(model, tokenizer, sentence, device):
-    tokenized_input = tokenizer(
-        sentence,
-        return_tensors="pt",
-        truncation=True,
-        add_special_tokens=True,
-        max_length=128
-    ).to(device)
 
-    with torch.no_grad():
-        outputs = model(
-            input_ids=tokenized_input["input_ids"],
-            attention_mask=tokenized_input["attention_mask"],
-            token_type_ids=tokenized_input.get("token_type_ids")
-        )
+class ModelService:
+    HF_MODEL = "kdyeon0309/gogo_forpanity_filter"
+    TOKENIZER = "beomi/KcELECTRA-base"
 
-    logits = outputs.logits.detach().cpu()
-    prediction = logits.argmax(-1).item()
-    return prediction
+    _model: Optional[AutoModelForSequenceClassification] = None
+    _tokenizer: Optional[AutoTokenizer] = None
+    _device: Optional[torch.device] = None
+    _load_lock = asyncio.Lock()
 
-async def predictor(comment):
-    comment = comment
-    hf_model = "kdyeon0309/gogo_forpanity_filter"
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model, tokenizer = await initialize_model_and_tokenizer(hf_model, device)
-    prediction= await predict_sentence(model, tokenizer, comment, device)
-    if prediction == 2:
-        prediction = 1
-    return prediction
+    @classmethod
+    async def load(cls) -> None:
+        async with cls._load_lock:
+            if cls._model is not None:
+                return
+
+            cls._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            logging.info(f"Loading profanity model '{cls.HF_MODEL}' on {cls._device}")
+
+            def _load_blocking():
+                model = AutoModelForSequenceClassification.from_pretrained(
+                    cls.HF_MODEL, trust_remote_code=True, use_auth_token=False
+                )
+                tokenizer = AutoTokenizer.from_pretrained(cls.TOKENIZER)
+                model.to(cls._device)
+                model.eval()
+                return model, tokenizer
+
+            cls._model, cls._tokenizer = await asyncio.to_thread(_load_blocking)
+            logging.info("Profanity model loaded")
+
+    @classmethod
+    def _predict_blocking(cls, sentence: str) -> int:
+        tokenized_input = cls._tokenizer(
+            sentence,
+            return_tensors="pt",
+            truncation=True,
+            add_special_tokens=True,
+            max_length=128,
+        ).to(cls._device)
+
+        with torch.no_grad():
+            outputs = cls._model(
+                input_ids=tokenized_input["input_ids"],
+                attention_mask=tokenized_input["attention_mask"],
+                token_type_ids=tokenized_input.get("token_type_ids"),
+            )
+
+        return outputs.logits.detach().cpu().argmax(-1).item()
+
+    @classmethod
+    async def predict(cls, sentence: str) -> int:
+        if cls._model is None:
+            await cls.load()
+
+        prediction = await asyncio.to_thread(cls._predict_blocking, sentence)
+        if prediction == 2:
+            prediction = 1
+        return prediction
+
+
+async def predictor(comment: str) -> int:
+    return await ModelService.predict(comment)

--- a/gogo_ai_backend/server.py
+++ b/gogo_ai_backend/server.py
@@ -4,11 +4,13 @@ import asyncio
 import uvicorn
 from middleware import LoggingMiddleware
 from event.consumer import consume
+from predict_model import ModelService
 from contextlib import asynccontextmanager
 # from eureka import init_eureka
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    await ModelService.load()
     asyncio.create_task(consume())  # 비동기 태스크 실행
     yield
  


### PR DESCRIPTION
## 개요
추론 시 매 요청마다 HuggingFace에서 모델/토크나이저를 다시 받아 디바이스에 올려 Kafka 메시지 1건당 수 초 단위 latency가 발생하던 문제 해결.

## 변경 사항
- `ModelService` 싱글톤으로 모델/토크나이저를 1회만 로드 후 재사용
- FastAPI lifespan에서 서버 기동 시 사전 로드해 첫 메시지 cold start 제거
- 동기 torch 호출은 `asyncio.to_thread`로 분리해 이벤트 루프 블로킹 제거
- 동시 호출 시 중복 로드 방지를 위한 `asyncio.Lock` 추가

Fixes #87