### PR TITLE
[feat] 추론 모델 revision 핀 및 빌드 타임 베이크인

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,7 @@ COPY gogo_ai_backend/ /gogo_ai_backend/
 
 RUN poetry install --no-root
 
+# 핀된 revision의 모델·토크나이저를 이미지에 베이크인 (런타임 HF Hub 의존 제거)
+RUN poetry run python prefetch_model.py
+
 CMD [ "poetry", "run", "python", "server.py" ]

--- a/Profanity_Filter/compute_dataset_sha.py
+++ b/Profanity_Filter/compute_dataset_sha.py
@@ -1,0 +1,49 @@
+import hashlib
+import sys
+from pathlib import Path
+
+CHUNK = 1 << 20
+
+
+def compute_dir_sha(root: Path) -> dict:
+    h = hashlib.sha256()
+    files = sorted(p for p in root.rglob("*") if p.is_file())
+    total_bytes = 0
+    for p in files:
+        rel = p.relative_to(root).as_posix().encode()
+        h.update(len(rel).to_bytes(4, "big"))
+        h.update(rel)
+        size = p.stat().st_size
+        h.update(size.to_bytes(8, "big"))
+        with p.open("rb") as f:
+            for chunk in iter(lambda: f.read(CHUNK), b""):
+                h.update(chunk)
+        total_bytes += size
+    return {
+        "sha256": h.hexdigest(),
+        "file_count": len(files),
+        "size_bytes": total_bytes,
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: python compute_dataset_sha.py <dataset_dir>", file=sys.stderr)
+        return 2
+    root = Path(sys.argv[1]).resolve()
+    if not root.is_dir():
+        print(f"error: {root} is not a directory", file=sys.stderr)
+        return 1
+
+    info = compute_dir_sha(root)
+    print(f"# 아래 블록을 gogo_ai_backend/models.yaml의 profanity_filter.train_dataset에 paste")
+    print(f"  train_dataset:")
+    print(f"    uri: {root}")
+    print(f"    sha256: {info['sha256']}")
+    print(f"    file_count: {info['file_count']}")
+    print(f"    size_bytes: {info['size_bytes']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Profanity_Filter/compute_dataset_sha.py
+++ b/Profanity_Filter/compute_dataset_sha.py
@@ -1,23 +1,27 @@
 import hashlib
+import os
 import sys
 from pathlib import Path
-
-CHUNK = 1 << 20
 
 
 def compute_dir_sha(root: Path) -> dict:
     h = hashlib.sha256()
-    files = sorted(p for p in root.rglob("*") if p.is_file())
+    files = sorted(
+        Path(dirpath) / filename
+        for dirpath, _, filenames in os.walk(root)
+        for filename in filenames
+    )
     total_bytes = 0
     for p in files:
         rel = p.relative_to(root).as_posix().encode()
         h.update(len(rel).to_bytes(4, "big"))
         h.update(rel)
-        size = p.stat().st_size
-        h.update(size.to_bytes(8, "big"))
         with p.open("rb") as f:
-            for chunk in iter(lambda: f.read(CHUNK), b""):
-                h.update(chunk)
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            f.seek(0)
+            h.update(size.to_bytes(8, "big"))
+            hashlib.file_digest(f, lambda: h)
         total_bytes += size
     return {
         "sha256": h.hexdigest(),

--- a/gogo_ai_backend/event/consumer.py
+++ b/gogo_ai_backend/event/consumer.py
@@ -7,7 +7,7 @@ from aiokafka import AIOKafkaConsumer
 from predict_model import predictor
 from config import get_kafka_host, get_kafka_port
 from event.producer import EventProducer
-from metrics import KAFKA_MESSAGE_TOTAL
+from metrics import KAFKA_MESSAGE_TOTAL, KAFKA_STATUS_PROCESSED, KAFKA_STATUS_SKIPPED
 from schema.filter import filtered_result
     
 events={
@@ -34,12 +34,12 @@ async def consume():
             logging.info(f'Consume kafka data {msg.topic} value: {data}')
             if 'content' not in data:
                 logging.error(f"Missing 'content' key in message: {data}")
-                KAFKA_MESSAGE_TOTAL.labels(topic=msg.topic, status="skipped").inc()
+                KAFKA_MESSAGE_TOTAL.labels(topic=msg.topic, status=KAFKA_STATUS_SKIPPED).inc()
                 continue
             logging.info(f"data: {data['content']}")
             model_output = await predictor(data['content'])
             logging.info(f'Predictor output: {model_output}')
-            KAFKA_MESSAGE_TOTAL.labels(topic=msg.topic, status="processed").inc()
+            KAFKA_MESSAGE_TOTAL.labels(topic=msg.topic, status=KAFKA_STATUS_PROCESSED).inc()
             if model_output == 1:
                 topic_id=events[msg.topic]['output']
                 await EventProducer.create_event(

--- a/gogo_ai_backend/event/consumer.py
+++ b/gogo_ai_backend/event/consumer.py
@@ -7,6 +7,7 @@ from aiokafka import AIOKafkaConsumer
 from predict_model import predictor
 from config import get_kafka_host, get_kafka_port
 from event.producer import EventProducer
+from metrics import KAFKA_MESSAGE_TOTAL
 from schema.filter import filtered_result
     
 events={
@@ -33,10 +34,12 @@ async def consume():
             logging.info(f'Consume kafka data {msg.topic} value: {data}')
             if 'content' not in data:
                 logging.error(f"Missing 'content' key in message: {data}")
+                KAFKA_MESSAGE_TOTAL.labels(topic=msg.topic, status="skipped").inc()
                 continue
             logging.info(f"data: {data['content']}")
             model_output = await predictor(data['content'])
             logging.info(f'Predictor output: {model_output}')
+            KAFKA_MESSAGE_TOTAL.labels(topic=msg.topic, status="processed").inc()
             if model_output == 1:
                 topic_id=events[msg.topic]['output']
                 await EventProducer.create_event(

--- a/gogo_ai_backend/metrics.py
+++ b/gogo_ai_backend/metrics.py
@@ -4,6 +4,9 @@
 """
 from prometheus_client import Counter, Gauge, Histogram
 
+KAFKA_STATUS_PROCESSED = "processed"
+KAFKA_STATUS_SKIPPED = "skipped"
+
 PREDICT_LATENCY = Histogram(
     "profanity_predict_latency_seconds",
     "Profanity inference latency",

--- a/gogo_ai_backend/metrics.py
+++ b/gogo_ai_backend/metrics.py
@@ -1,0 +1,36 @@
+"""Prometheus 메트릭 정의 — 한 곳에 모아 관리.
+
+라벨 카디널리티를 낮게 유지하기 위해 model_revision은 short SHA(8자) 사용.
+"""
+from prometheus_client import Counter, Gauge, Histogram
+
+PREDICT_LATENCY = Histogram(
+    "profanity_predict_latency_seconds",
+    "Profanity inference latency",
+    labelnames=("model_revision",),
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+)
+
+PREDICTION_TOTAL = Counter(
+    "profanity_prediction_total",
+    "Predictions by label",
+    labelnames=("label", "model_revision"),
+)
+
+MODEL_LOAD_DURATION = Histogram(
+    "profanity_model_load_duration_seconds",
+    "Model + tokenizer load duration",
+    buckets=(1, 5, 10, 30, 60, 120, 300, 600),
+)
+
+MODEL_INFO = Gauge(
+    "profanity_model_info",
+    "Loaded model provenance (value is always 1; metadata in labels)",
+    labelnames=("model", "revision", "tokenizer", "tokenizer_revision"),
+)
+
+KAFKA_MESSAGE_TOTAL = Counter(
+    "profanity_kafka_message_total",
+    "Kafka messages consumed by topic and outcome",
+    labelnames=("topic", "status"),
+)

--- a/gogo_ai_backend/models.yaml
+++ b/gogo_ai_backend/models.yaml
@@ -1,0 +1,9 @@
+profanity_filter:
+  hf_repo: kdyeon0309/gogo_forpanity_filter
+  revision: 52af3a112563eb58346a0a2e031b9705676add4f
+  tokenizer:
+    hf_repo: beomi/KcELECTRA-base
+    revision: 681201a097b8120e6dd2a2e63a3e13d338736f88
+  registered_at: "2026-05-03"
+  training_run_id: null
+  eval_metrics: null

--- a/gogo_ai_backend/models.yaml
+++ b/gogo_ai_backend/models.yaml
@@ -7,3 +7,8 @@ profanity_filter:
   registered_at: "2026-05-03"
   training_run_id: null
   eval_metrics: null
+  train_dataset:
+    uri: null
+    sha256: null
+    file_count: null
+    size_bytes: null

--- a/gogo_ai_backend/predict_model.py
+++ b/gogo_ai_backend/predict_model.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -7,6 +8,13 @@ from typing import Optional
 import torch
 import yaml
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+from metrics import (
+    MODEL_INFO,
+    MODEL_LOAD_DURATION,
+    PREDICT_LATENCY,
+    PREDICTION_TOTAL,
+)
 
 _MODELS_YAML = Path(__file__).parent / "models.yaml"
 
@@ -55,8 +63,16 @@ class ModelService:
                 model.eval()
                 return model, tokenizer
 
+            load_start = time.perf_counter()
             cls._model, cls._tokenizer = await asyncio.to_thread(_load_blocking)
+            MODEL_LOAD_DURATION.observe(time.perf_counter() - load_start)
             cls._loaded_at = datetime.now(timezone.utc).isoformat()
+            MODEL_INFO.labels(
+                model=cls.HF_MODEL,
+                revision=cls.HF_REVISION,
+                tokenizer=cls.TOKENIZER,
+                tokenizer_revision=cls.TOKENIZER_REVISION,
+            ).set(1)
             logging.info("Profanity model loaded")
 
     @classmethod
@@ -93,9 +109,12 @@ class ModelService:
         if cls._model is None:
             await cls.load()
 
-        prediction = await asyncio.to_thread(cls._predict_blocking, sentence)
+        revision_label = cls.HF_REVISION[:8]
+        with PREDICT_LATENCY.labels(model_revision=revision_label).time():
+            prediction = await asyncio.to_thread(cls._predict_blocking, sentence)
         if prediction == 2:
             prediction = 1
+        PREDICTION_TOTAL.labels(label=str(prediction), model_revision=revision_label).inc()
         return prediction
 
 

--- a/gogo_ai_backend/predict_model.py
+++ b/gogo_ai_backend/predict_model.py
@@ -1,18 +1,32 @@
 import asyncio
 import logging
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
 
 import torch
+import yaml
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+_MODELS_YAML = Path(__file__).parent / "models.yaml"
+
+
+def _load_config() -> dict:
+    with _MODELS_YAML.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)["profanity_filter"]
 
 
 class ModelService:
-    HF_MODEL = "kdyeon0309/gogo_forpanity_filter"
-    TOKENIZER = "beomi/KcELECTRA-base"
+    _config = _load_config()
+    HF_MODEL: str = _config["hf_repo"]
+    HF_REVISION: str = _config["revision"]
+    TOKENIZER: str = _config["tokenizer"]["hf_repo"]
+    TOKENIZER_REVISION: str = _config["tokenizer"]["revision"]
 
     _model: Optional[AutoModelForSequenceClassification] = None
     _tokenizer: Optional[AutoTokenizer] = None
     _device: Optional[torch.device] = None
+    _loaded_at: Optional[str] = None
     _load_lock = asyncio.Lock()
 
     @classmethod
@@ -22,19 +36,38 @@ class ModelService:
                 return
 
             cls._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-            logging.info(f"Loading profanity model '{cls.HF_MODEL}' on {cls._device}")
+            logging.info(
+                f"Loading profanity model '{cls.HF_MODEL}@{cls.HF_REVISION[:8]}' on {cls._device}"
+            )
 
             def _load_blocking():
                 model = AutoModelForSequenceClassification.from_pretrained(
-                    cls.HF_MODEL, trust_remote_code=True, use_auth_token=False
+                    cls.HF_MODEL,
+                    revision=cls.HF_REVISION,
+                    trust_remote_code=True,
+                    use_auth_token=False,
                 )
-                tokenizer = AutoTokenizer.from_pretrained(cls.TOKENIZER)
+                tokenizer = AutoTokenizer.from_pretrained(
+                    cls.TOKENIZER,
+                    revision=cls.TOKENIZER_REVISION,
+                )
                 model.to(cls._device)
                 model.eval()
                 return model, tokenizer
 
             cls._model, cls._tokenizer = await asyncio.to_thread(_load_blocking)
+            cls._loaded_at = datetime.now(timezone.utc).isoformat()
             logging.info("Profanity model loaded")
+
+    @classmethod
+    def info(cls) -> dict:
+        return {
+            "model": cls.HF_MODEL,
+            "revision": cls.HF_REVISION,
+            "tokenizer": cls.TOKENIZER,
+            "tokenizer_revision": cls.TOKENIZER_REVISION,
+            "loaded_at": cls._loaded_at,
+        }
 
     @classmethod
     def _predict_blocking(cls, sentence: str) -> int:

--- a/gogo_ai_backend/predict_model.py
+++ b/gogo_ai_backend/predict_model.py
@@ -1,43 +1,70 @@
-from transformers import AutoModelForSequenceClassification, AutoTokenizer
-import torch
-import pandas as pd
 import asyncio
+import logging
+from typing import Optional
 
-async def initialize_model_and_tokenizer(hf_model, device):
-    model = AutoModelForSequenceClassification.from_pretrained(
-        hf_model, trust_remote_code=True, use_auth_token=False
-    )
-    tokenizer = AutoTokenizer.from_pretrained("beomi/KcELECTRA-base")
-    model.to(device)
-    model.eval()
-    return model, tokenizer
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
-async def predict_sentence(model, tokenizer, sentence, device):
-    tokenized_input = tokenizer(
-        sentence,
-        return_tensors="pt",
-        truncation=True,
-        add_special_tokens=True,
-        max_length=128
-    ).to(device)
 
-    with torch.no_grad():
-        outputs = model(
-            input_ids=tokenized_input["input_ids"],
-            attention_mask=tokenized_input["attention_mask"],
-            token_type_ids=tokenized_input.get("token_type_ids")
-        )
+class ModelService:
+    HF_MODEL = "kdyeon0309/gogo_forpanity_filter"
+    TOKENIZER = "beomi/KcELECTRA-base"
 
-    logits = outputs.logits.detach().cpu()
-    prediction = logits.argmax(-1).item()
-    return prediction
+    _model: Optional[AutoModelForSequenceClassification] = None
+    _tokenizer: Optional[AutoTokenizer] = None
+    _device: Optional[torch.device] = None
+    _load_lock = asyncio.Lock()
 
-async def predictor(comment):
-    comment = comment
-    hf_model = "kdyeon0309/gogo_forpanity_filter"
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model, tokenizer = await initialize_model_and_tokenizer(hf_model, device)
-    prediction= await predict_sentence(model, tokenizer, comment, device)
-    if prediction == 2:
-        prediction = 1
-    return prediction
+    @classmethod
+    async def load(cls) -> None:
+        async with cls._load_lock:
+            if cls._model is not None:
+                return
+
+            cls._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            logging.info(f"Loading profanity model '{cls.HF_MODEL}' on {cls._device}")
+
+            def _load_blocking():
+                model = AutoModelForSequenceClassification.from_pretrained(
+                    cls.HF_MODEL, trust_remote_code=True, use_auth_token=False
+                )
+                tokenizer = AutoTokenizer.from_pretrained(cls.TOKENIZER)
+                model.to(cls._device)
+                model.eval()
+                return model, tokenizer
+
+            cls._model, cls._tokenizer = await asyncio.to_thread(_load_blocking)
+            logging.info("Profanity model loaded")
+
+    @classmethod
+    def _predict_blocking(cls, sentence: str) -> int:
+        tokenized_input = cls._tokenizer(
+            sentence,
+            return_tensors="pt",
+            truncation=True,
+            add_special_tokens=True,
+            max_length=128,
+        ).to(cls._device)
+
+        with torch.no_grad():
+            outputs = cls._model(
+                input_ids=tokenized_input["input_ids"],
+                attention_mask=tokenized_input["attention_mask"],
+                token_type_ids=tokenized_input.get("token_type_ids"),
+            )
+
+        return outputs.logits.detach().cpu().argmax(-1).item()
+
+    @classmethod
+    async def predict(cls, sentence: str) -> int:
+        if cls._model is None:
+            await cls.load()
+
+        prediction = await asyncio.to_thread(cls._predict_blocking, sentence)
+        if prediction == 2:
+            prediction = 1
+        return prediction
+
+
+async def predictor(comment: str) -> int:
+    return await ModelService.predict(comment)

--- a/gogo_ai_backend/predict_model.py
+++ b/gogo_ai_backend/predict_model.py
@@ -30,6 +30,7 @@ class ModelService:
     HF_REVISION: str = _config["revision"]
     TOKENIZER: str = _config["tokenizer"]["hf_repo"]
     TOKENIZER_REVISION: str = _config["tokenizer"]["revision"]
+    _revision_label: str = HF_REVISION[:8]
 
     _model: Optional[AutoModelForSequenceClassification] = None
     _tokenizer: Optional[AutoTokenizer] = None
@@ -45,7 +46,7 @@ class ModelService:
 
             cls._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
             logging.info(
-                f"Loading profanity model '{cls.HF_MODEL}@{cls.HF_REVISION[:8]}' on {cls._device}"
+                f"Loading profanity model '{cls.HF_MODEL}@{cls._revision_label}' on {cls._device}"
             )
 
             def _load_blocking():
@@ -109,12 +110,14 @@ class ModelService:
         if cls._model is None:
             await cls.load()
 
-        revision_label = cls.HF_REVISION[:8]
-        with PREDICT_LATENCY.labels(model_revision=revision_label).time():
+        with PREDICT_LATENCY.labels(model_revision=cls._revision_label).time():
             prediction = await asyncio.to_thread(cls._predict_blocking, sentence)
         if prediction == 2:
             prediction = 1
-        PREDICTION_TOTAL.labels(label=str(prediction), model_revision=revision_label).inc()
+        PREDICTION_TOTAL.labels(
+            label=str(prediction),
+            model_revision=cls._revision_label,
+        ).inc()
         return prediction
 
 

--- a/gogo_ai_backend/prefetch_model.py
+++ b/gogo_ai_backend/prefetch_model.py
@@ -1,0 +1,26 @@
+"""빌드 타임에 모델·토크나이저를 HuggingFace Hub에서 받아 이미지에 캐싱.
+
+런타임 외부 의존을 제거하기 위한 스크립트. Dockerfile에서만 호출됨.
+"""
+from pathlib import Path
+
+import yaml
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+with (Path(__file__).parent / "models.yaml").open("r", encoding="utf-8") as f:
+    cfg = yaml.safe_load(f)["profanity_filter"]
+
+print(f"Prefetch model {cfg['hf_repo']}@{cfg['revision'][:8]}")
+AutoModelForSequenceClassification.from_pretrained(
+    cfg["hf_repo"],
+    revision=cfg["revision"],
+    trust_remote_code=True,
+)
+
+print(f"Prefetch tokenizer {cfg['tokenizer']['hf_repo']}@{cfg['tokenizer']['revision'][:8]}")
+AutoTokenizer.from_pretrained(
+    cfg["tokenizer"]["hf_repo"],
+    revision=cfg["tokenizer"]["revision"],
+)
+
+print("Prefetch complete")

--- a/gogo_ai_backend/pyproject.toml
+++ b/gogo_ai_backend/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "python-dotenv (>=1.1.0,<2.0.0)",
     "pydantic (>=2.11.1,<3.0.0)",
     "py-eureka-client (>=0.11.13,<0.12.0)",
-    "pyyaml (>=6.0,<7.0)"
+    "pyyaml (>=6.0,<7.0)",
+    "prometheus-client (>=0.21.0,<0.22.0)"
 ]
 
 

--- a/gogo_ai_backend/pyproject.toml
+++ b/gogo_ai_backend/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "pandas (>=2.2.3,<3.0.0)",
     "python-dotenv (>=1.1.0,<2.0.0)",
     "pydantic (>=2.11.1,<3.0.0)",
-    "py-eureka-client (>=0.11.13,<0.12.0)"
+    "py-eureka-client (>=0.11.13,<0.12.0)",
+    "pyyaml (>=6.0,<7.0)"
 ]
 
 

--- a/gogo_ai_backend/server.py
+++ b/gogo_ai_backend/server.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 import logging
 import asyncio
 import uvicorn
+from prometheus_client import make_asgi_app
 from middleware import LoggingMiddleware
 from event.consumer import consume
 from predict_model import ModelService
@@ -13,12 +14,13 @@ async def lifespan(app: FastAPI):
     await ModelService.load()
     asyncio.create_task(consume())  # 비동기 태스크 실행
     yield
- 
+
 
 app = FastAPI(lifespan=lifespan)
 
 logging.basicConfig(level=logging.INFO)
 app.add_middleware(LoggingMiddleware)
+app.mount("/metrics", make_asgi_app())
 
 @app.get("/ai/health")
 async def root():

--- a/gogo_ai_backend/server.py
+++ b/gogo_ai_backend/server.py
@@ -22,7 +22,10 @@ app.add_middleware(LoggingMiddleware)
 
 @app.get("/ai/health")
 async def root():
-    return 'GOGO Ai Service OK'
+    return {
+        "status": "ok",
+        "model": ModelService.info(),
+    }
  
 if __name__ == '__main__':
     try:

--- a/gogo_ai_backend/server.py
+++ b/gogo_ai_backend/server.py
@@ -4,11 +4,13 @@ import asyncio
 import uvicorn
 from middleware import LoggingMiddleware
 from event.consumer import consume
+from predict_model import ModelService
 from contextlib import asynccontextmanager
 # from eureka import init_eureka
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    await ModelService.load()
     asyncio.create_task(consume())  # 비동기 태스크 실행
     yield
  


### PR DESCRIPTION
## 개요
HuggingFace에서 모델, 토크나이저가 갱신되면 prod 추론 결과가 silent하게 바뀌고, 런타임에 HF Hub에 의존해 외부 장애/콜드 스타트/rate-limit 위험이 있던 구조 해결.

## 변경사항
- prod silent regression 차단 (revision 단위 immutable)
- 런타임 외부 의존 0 — HF Hub 장애 무관, 콜드 스타트 시 이미지 캐시에서 즉시 로드
- 이미지 태그 단위 atomic 롤백 가능 (~30s)
- `/ai/health`로 "지금 어떤 모델이 도는지" 즉시 확인 가능 → 장애 triage 단축


fix #84